### PR TITLE
Updated animation code to speed up execution and lower memory consumption

### DIFF
--- a/ThreeBodyProblem.m
+++ b/ThreeBodyProblem.m
@@ -19,27 +19,13 @@ x10 = P(1, 1); y10 = P(2, 1);
 x20 = P(1, 2); y20 = P(2, 2);
 x30 = P(1, 3); y30 = P(2, 3);
 
-% Set up figure for plotting
-figure;
-axis([-100 60 -100 60]); % Adjust axis limits as needed
-hold on;
-grid on; % Add a grid for better visualization
-title('Simulation Graphic');
-xlabel('x');
-ylabel('y');
-
 time = 0:dt:100;
 
 % Preallocate arrays for trajectory plotting
 x1 = 0*time; y1 = x1;
 x2 = x1;     y2 = x1;
 x3 = x1;     y3 = x1;
-
-% Initialize plot handles for bodies
-plotHandle1 = plot(P(1,1), P(2,1), 'ro', 'MarkerFaceColor', 'r'); % Body 1
-plotHandle2 = plot(P(1,2), P(2,2), 'go', 'MarkerFaceColor', 'g'); % Body 2
-plotHandle3 = plot(P(1,3), P(2,3), 'bo', 'MarkerFaceColor', 'b'); % Body 3
-
+fprintf("Computing\n");
 tic
 for i = 1:1:length(time)
 
@@ -87,39 +73,45 @@ for i = 1:1:length(time)
     x3(i) = P(1,3);
     y3(i) = P(2,3);
 
-%    % Update the positions of the bodies in the plot
-%    set(plotHandle1, 'XData', P(1,1), 'YData', P(2,1));
-%    set(plotHandle2, 'XData', P(1,2), 'YData', P(2,2));
-%    set(plotHandle3, 'XData', P(1,3), 'YData', P(2,3));
-
-    % Plot the new positions of the bodies and their trajectories
-%    plot(x1(1:t), y1(1:t), 'r', 'LineWidth', 1);
-%    plot(x2(1:t), y2(1:t), 'g', 'LineWidth', 1);
-%    plot(x3(1:t), y3(1:t), 'b', 'LineWidth', 1);
-
-%    drawnow 
 end
-
 toc
 
-%%plot
+fprintf("Making Animation\n");
+tic
+
+% Plot the objects
+h1 = plot(x1(1), y1(1), 'ro', 'MarkerFaceColor', 'r'); 
+axis([-100 60 -100 60]); % Adjust axis limits as needed
+grid on; % Add a grid for better visualization;
+xlabel('x');
+ylabel('y');
+
+hold on
+h2 = plot(x2(1), y2(1), 'go', 'MarkerFaceColor', 'g');
+h3 = plot(x3(1), y3(1), 'bo', 'MarkerFaceColor', 'b');
+% Plot the trails
+t1 = plot(NaN, NaN, 'r-'); % plot the trail
+t2 = plot(NaN, NaN, 'g-'); % plot the trail
+t3 = plot(NaN, NaN, 'b-'); % plot the trail
+
+
+%% Plot the trails
 
 dtplot = 0.1;
-
 for i=1:floor(dtplot/dt):length(time)
     % Update the positions of the bodies in the plot
-   set(plotHandle1, 'XData', x1(i), 'YData', y1(i));
-    set(plotHandle2, 'XData', x2(i), 'YData', y2(i));
-    set(plotHandle3, 'XData', x3(i), 'YData', y3(i));
-
-    % Plot the new positions of the bodies and their trajectories
-    plot(x1(1:i), y1(1:i), 'r');
-    plot(x2(1:i), y2(1:i), 'g');
-    plot(x3(1:i), y3(1:i), 'b');
-     
+    set(h1, 'XData', x1(i), 'YData', y1(i))
+    set(h2, 'XData', x2(i), 'YData', y2(i))
+    set(h3, 'XData', x3(i), 'YData', y3(i))
+    % Update the trails
+    set(t1, 'XData', x1(1:i), 'YData', y1(1:i))
+    set(t2, 'XData', x2(1:i), 'YData', y2(1:i))
+    set(t3, 'XData', x3(1:i), 'YData', y3(1:i))
     title(['Simulation Graphic at t =',num2str(time(i)) ]);
-    pause(eps*10^10)
+    drawnow
     if (max([abs(x1(i)),abs(x2(i)),abs(x1(i))])>10^5)
         break
     end
 end
+hold off
+toc


### PR DESCRIPTION
I noticed that running this script resulted in high memory consumption that grew over time.  Make a simulation long enough and you'll run out of memory.  Here's my task manager after running the original code on MATLAB R2024b - around 22Gb RAM used. 

![Memory_OriginalVersion](https://github.com/user-attachments/assets/f42dc686-ec40-4eee-8996-6587012f090f)

This PR uses much less RAM since it reuses the same plots for each animation frame.  Around 2Gb and it doesn't grow over time.

![Memory_updatedAnimation#](https://github.com/user-attachments/assets/f2f5b7ea-e2d6-4e7f-af32-97281b4feca7)


This PR also produces the animation more quickly.  I added separate tic/toc commands to the computation and animation making to show this.

# Using MATLAB R2024b:

**Original Version**
```
>> ThreeBodyProblem
Computing
Elapsed time is 1.752359 seconds.
Making animation
Elapsed time is 164.394720 second
```

**This PR**
```
>> ThreeBodyProblem
Computing
Elapsed time is 1.731459 seconds.
Making Animation
Elapsed time is 121.653909 seconds.
```

The real benefit comes from using R2025a (currently only the pre-release is available but I suggest you go and give it a try!) which has had all of the User Interface and Graphics completely re-done.

# MATLAB R2025a pre-release
**Original version** 

```
>> ThreeBodyProblem
Computing
Elapsed time is 1.801636 seconds.
Making animation
Elapsed time is 90.408749 seconds
```

**This PR**
```
>> ThreeBodyProblem
Computing
Elapsed time is 1.766398 seconds.
Making Animation
Elapsed time is 30.884085 seconds
```